### PR TITLE
Patch for Earlier Unity Versions

### DIFF
--- a/Editor/MissingScriptsFinder.cs
+++ b/Editor/MissingScriptsFinder.cs
@@ -10,6 +10,10 @@
 //
 // **************************************************************** //
 
+#if !UNITY_2020_OR_NEWER && !UNITY_2020_1_OR_NEWER
+using System.Linq;
+#endif
+
 using UnityEditor;
 using UnityEngine;
 using UnityEditor.SceneManagement;
@@ -42,8 +46,17 @@ namespace AbyssMoth
                 : FindObjectsInactive.Exclude;
 
             return Object.FindObjectsByType<GameObject>(inactiveMode, FindObjectsSortMode.InstanceID);
-#else
+#elif UNITY_2020_OR_NEWER || UNITY_2020_1_OR_NEWER
             return Object.FindObjectsOfType<GameObject>(includeInactive);
+#else
+            if (includeInactive)
+            {
+                return Resources.FindObjectsOfTypeAll<GameObject>().Cast<GameObject>().ToArray();
+            }
+            else
+            {
+                return Object.FindObjectsOfType<GameObject>();
+            }
 #endif
         }
 


### PR DESCRIPTION
Prior to Unity 2020, `Object.FindObjectsOfType<T>(boolean)` is not available and `Object.FindObjectsOfType<T>()` will return only active objects

For the preprocessor directives-- not all versions of Unity 2020 have the same ones defined for that version: https://discussions.unity.com/t/unity_2019_or_newer-not-recognised-in-unity-2020/815014

Making it safer to check for both, though it is admittedly a little ugly

Tested on Unity Versions 2018.4.36f1 (LTS), 2019.4.40f1 (LTS), and 2020.3.6f1 (LTS)
